### PR TITLE
Rational support: restrict- functions and divide-and-conquer-force

### DIFF
--- a/equations.lisp
+++ b/equations.lisp
@@ -8,6 +8,8 @@
  (eval-when (:compile-toplevel :load-toplevel)
   (require :iterate))
 
+#+lispworks(setf sys::*stack-overflow-behaviour* :warn)
+
 (screamer:define-screamer-package :screams (:use :iterate))
 
 (in-package :screams)
@@ -166,7 +168,7 @@
      (reorder #'range-size
  	     #'(lambda (x) (< x 1/1000000))
  	     #'>
- 	     #'divide-and-conquer-force))))
+ 	     #'divide-and-conquer-force)))))
 		 
 				 
 (defun eq3 () (for-effects (print (solve '((= (* 4 x) 3))))))
@@ -194,13 +196,13 @@
  (for-effects
   (print
    (solution
-    (let ((x (a-rational-betweenv -1000000 1000000 1000000))
-	  (y (a-rational-betweenv -1000000 1000000 1000000)))
+    (let ((x (a-rational-betweenv -1000000 1000000 10))
+	  (y (a-rational-betweenv -1000000 1000000 10)))
      (assert! (andv (=v (+v x x y y y) 17)
 		    (=v (+v x x x x x x x y y y y) 27)))
      (list x y))
     (reorder #'range-size
-	     #'(lambda (x) (< x 1/1000000))
+	     #'(lambda (x) (< x 1/10))
 	     #'>
 	     #'divide-and-conquer-force)))))
 	 
@@ -276,7 +278,7 @@
       (assert! (andv (=v (+v (*v 2 x) (*v 3 y)) 17)
  		    (=v (+v (*v 7 x) (*v 4 y)) 27)))
       (list x y))
-     (reorder #'range-size
+     (reorder #'domain-size
  	     #'(lambda (x) (< x 1/1000000))
  	     #'>
  	     #'divide-and-conquer-force)))))
@@ -434,7 +436,7 @@
      (let ((x (a-rational-betweenv -1000000 1000000 1000000)))
       (assert! (=v (+v x x x x) 8))
       x)
-     (reorder #'range-size
+     (reorder #'domain-size
  	     #'(lambda (x) (< x 1/1000000))
  	     #'>
  	     #'divide-and-conquer-force)))))
@@ -490,7 +492,7 @@
           (=v (+v (*v 3 x y) (*v 2 y y) (*v 5 x y z)) -4))
         (>=v (*v (+v x y) (+v y z)) -5)))
     (list x y z))
- (reorder #'range-size
+ (reorder #'domain-size
          #'(lambda (x) (< x 1/10))
          #'>
          #'divide-and-conquer-force)))))


### PR DESCRIPTION
- Use typecase for closest-ratio/rational functions
- Use *maximum-discretization-range* for ratio/rational enumerations
- New conditions for ratio/rationals in restrict-lower-bound!, upper-bound! and bounds!
- New conditions for ratio/rational individe-and-conquer-force.